### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/app/api/generate-resume-pdf/route.tsx
+++ b/app/api/generate-resume-pdf/route.tsx
@@ -65,11 +65,30 @@ const IconMapPin = () => (
   </Svg>
 );
 
+const isXDotComHost = (value: string) => {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return false;
+
+  const parseHostname = (input: string) => {
+    try {
+      return new URL(input).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  };
+
+  const hostname =
+    parseHostname(trimmed) ??
+    parseHostname(`https://${trimmed}`);
+
+  return hostname === "x.com" || (hostname !== null && hostname.endsWith(".x.com"));
+};
+
 const SocialIcon = ({ platform }: { platform: string }) => {
   const p = platform.toLowerCase();
   if (p.includes('github')) return <IconGithub />;
   if (p.includes('linkedin')) return <IconLinkedin />;
-  if (p.includes('twitter') || p.includes('x.com')) return <IconTwitter />;
+  if (p.includes('twitter') || isXDotComHost(platform)) return <IconTwitter />;
   if (p.includes('mail') || p.includes('email')) return <IconMail />;
   if (p.includes('globe') || p.includes('website') || p.includes('portfolio')) return <IconGlobe />;
   if (p.includes('phone') || p.includes('call')) return <IconPhone />;


### PR DESCRIPTION
Potential fix for [https://github.com/MACM18/resume/security/code-scanning/9](https://github.com/MACM18/resume/security/code-scanning/9)

Use URL parsing when checking for `x.com`, and only match the hostname (with safe subdomain handling), while preserving existing behavior for non-URL labels.

Best fix in this file:  
- In `SocialIcon` (around lines 68–77), replace `p.includes('x.com')` with a helper-based hostname check.
- Add a small local helper `isXDotComHost(value: string): boolean` that:
  - Parses with `new URL(...)` (with a fallback `https://` prefix for bare hosts),
  - Extracts `hostname.toLowerCase()`,
  - Returns true only for `x.com` or subdomains ending with `.x.com`.
- Keep the existing `"twitter"` substring check so labels like `"Twitter"` still work.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
